### PR TITLE
Add primary and negative color

### DIFF
--- a/src/components/features/Discover/NearbyAvatar.tsx
+++ b/src/components/features/Discover/NearbyAvatar.tsx
@@ -27,7 +27,7 @@ const styles = StyleSheet.create({
   },
   ring: {
     borderWidth: 3,
-    borderColor: vars.green.soft,
+    borderColor: vars.primaryColor.soft,
     padding: 2,
     width: 90,
     height: 90,

--- a/src/components/ui/AlertBubble.tsx
+++ b/src/components/ui/AlertBubble.tsx
@@ -27,14 +27,14 @@ const getStyles = (primary: boolean) =>
       borderRadius: 11,
       borderWidth: 1,
       backgroundColor: primary ? vars.backgroundColorGreen : vars.backgroundColorSecondary,
-      borderColor: primary ? vars.green.darkest : vars.backgroundColorSecondary,
+      borderColor: primary ? vars.primaryColor.darkest : vars.backgroundColorSecondary,
     },
     bubbleText: {
       paddingHorizontal: 10,
       fontSize: 13,
       fontFamily: vars.fontFamilySecondary,
       fontWeight: '700',
-      color: primary ? vars.green.text : vars.gray.softest,
+      color: primary ? vars.primaryColor.text : vars.gray.softest,
     },
   });
 

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -17,7 +17,7 @@ const Button = (props: any) => {
 
 const styles = StyleSheet.create({
   buttonStyleDefault: {
-    backgroundColor: vars.green.button,
+    backgroundColor: vars.primaryColor.button,
     borderRadius: 32,
     height: 50,
     width: 330,
@@ -29,7 +29,7 @@ const styles = StyleSheet.create({
     width: 330,
   },
   textStyleDefault: {
-    color: vars.green.text,
+    color: vars.primaryColor.text,
     fontFamily: vars.fontFamilySecondary,
     fontSize: 22,
     fontWeight: '700',

--- a/src/components/ui/TextBubble.tsx
+++ b/src/components/ui/TextBubble.tsx
@@ -49,9 +49,9 @@ const styles = StyleSheet.create({
     borderBottomLeftRadius: 12,
     borderBottomRightRadius: 0,
     borderWidth: 1,
-    borderColor: vars.green.soft,
+    borderColor: vars.primaryColor.soft,
     borderStyle: 'dashed',
-    backgroundColor: vars.green.darkest,
+    backgroundColor: vars.primaryColor.darkest,
   },
   failedBubble: {
     maxWidth: 300,
@@ -61,8 +61,8 @@ const styles = StyleSheet.create({
     borderBottomLeftRadius: 12,
     borderBottomRightRadius: 0,
     borderWidth: 1,
-    borderColor: vars.red.soft,
-    backgroundColor: vars.red.darkest,
+    borderColor: vars.negativeColor.soft,
+    backgroundColor: vars.negativeColor.darkest,
   },
   receivedBubble: {
     maxWidth: 300,
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 12,
     borderBottomLeftRadius: 12,
     borderBottomRightRadius: 0,
-    backgroundColor: vars.green.darker,
+    backgroundColor: vars.primaryColor.darker,
   },
   text: {
     paddingHorizontal: 13,

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -74,6 +74,8 @@ const aliases = {
   backgroundColor: colors.black.dark,
   backgroundColorSecondary: colors.black.soft,
   backgroundColorGreen: colors.green.background,
+  primaryColor: colors.green,
+  negativeColor: colors.red,
 };
 
 export const vars = {


### PR DESCRIPTION
## Why
If we want to change colours and stuff we should just be able to do it from theme.ts

This allows us to use vars.primaryColor (green right now) or vars.negativeColor (red right now) instead of explicitly saying the color. In the future we can add accent colors and stuff too.
## What Changed
Just changed the usage of greens and reds to be abstracted one level.

## Testing
Everything should work the same! Greens should still be greens.

## Extra
