### PR TITLE
HYP-80: Update Bridgefy SDK to version 0.3.0

### DIFF
--- a/ios/Hyperlocal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Hyperlocal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bridgefy/sdk-ios-beta",
       "state" : {
-        "revision" : "873798cda7e08ff3aaa9242fec37b0cbd46b398c",
-        "version" : "0.2.0"
+        "revision" : "e767da44c9cb819e8dcd3f445b5361aecff9ec74",
+        "version" : "0.3.0"
       }
     }
   ],

--- a/ios/Pods/Pods.xcodeproj/project.pbxproj
+++ b/ios/Pods/Pods.xcodeproj/project.pbxproj
@@ -22507,6 +22507,7 @@
 			baseConfigurationReference = 46EB2E000180E0 /* React-Core.release.xcconfig */;
 			buildSettings = {
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/React-Core";
+				DEVELOPMENT_TEAM = 4S4629NJ8Q;
 				IBSC_MODULE = React;
 				INFOPLIST_FILE = "Target Support Files/React-Core/ResourceBundle-AccessibilityResources-React-Core-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
@@ -22523,6 +22524,7 @@
 			baseConfigurationReference = 46EB2E000180D0 /* React-Core.debug.xcconfig */;
 			buildSettings = {
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/React-Core";
+				DEVELOPMENT_TEAM = 4S4629NJ8Q;
 				IBSC_MODULE = React;
 				INFOPLIST_FILE = "Target Support Files/React-Core/ResourceBundle-AccessibilityResources-React-Core-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;

--- a/ios/RCTBridgefySwift.m
+++ b/ios/RCTBridgefySwift.m
@@ -19,5 +19,8 @@ RCT_EXTERN_METHOD(sendMessage:
                 id: (NSString *)id
                 callback: (RCTResponseSenderBlock)callback
                 )
+RCT_EXTERN_METHOD(getUserId:
+                  (RCTResponseSenderBlock) callback
+                  )
 RCT_EXTERN_METHOD(supportedEvents)
 @end

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import {
   removeConnectionAtom,
   updateConversationCacheDeprecated,
 } from './services/atoms';
-import { createListeners, startSDK } from './services/bridgefy-link';
+import { createListeners, getUserId, startSDK } from './services/bridgefy-link';
 import { verifyChatInvitation } from './services/chat_invitations';
 import { getConnectionName } from './services/connections';
 import {
@@ -96,16 +96,30 @@ export default function App() {
     createListeners(
       onStart,
       onFailedToStart,
+      onStop,
+      onFailedToStop,
       onConnect,
       onDisconnect,
+      onEstablishedSecureConnection,
+      onFailedToEstablishSecureConnection,
       onMessageReceived,
       onMessageSent,
       onMessageSentFailed
     );
     setBridgefyStatus(BridgefyStates.STARTING);
-    startSDK().catch((error: number) => {
-      handleBridgefyError(error);
-    });
+    startSDK()
+      .then(() => {
+        getUserId()
+          .then((userID: string) => {
+            onBridgefyInit(userID);
+          })
+          .catch((error: number) => {
+            handleBridgefyError(error);
+          });
+      })
+      .catch((error: number) => {
+        handleBridgefyError(error);
+      });
     setAllUsers(getContactsArray());
     setConversationCache(createConversationCache());
   }, []);
@@ -155,6 +169,12 @@ export default function App() {
     }
   };
 
+  const onBridgefyInit = (userID: string) => {
+    console.log('(onBridgefyInit) Starting with user ID:', userID);
+    setUserInfo(getOrCreateUserInfoDatabase(userID, true)); // mark sdk as validated
+    setBridgefyStatus(BridgefyStates.ONLINE);
+  };
+
   /*
 
     EVENT LISTENERS
@@ -167,9 +187,8 @@ export default function App() {
   */
 
   // Runs on Bridgefy SDK start.
-  const onStart = (userID: string) => {
-    console.log('(onStart) Starting with user ID:', userID);
-    setUserInfo(getOrCreateUserInfoDatabase(userID, true)); // mark sdk as validated
+  const onStart = () => {
+    console.log('(onStart) Started Bridgefy');
     setBridgefyStatus(BridgefyStates.ONLINE);
   };
 
@@ -179,6 +198,18 @@ export default function App() {
 
     const errorCode: number = parseInt(error, 10);
     handleBridgefyError(errorCode);
+  };
+
+  // Runs on Bridgefy SDK stop.
+  const onStop = () => {
+    console.log('(onStop) Stopped');
+    setBridgefyStatus(BridgefyStates.OFFLINE);
+  };
+
+  // Runs on Bridgefy SDK stop failure.
+  const onFailedToStop = (error: string) => {
+    console.log('(onFailedToStop) Failed to stop:', error);
+    setBridgefyStatus(BridgefyStates.FAILED);
   };
 
   // Runs on connection to another user.
@@ -228,6 +259,21 @@ export default function App() {
     if (isContact(connectedID)) {
       updateLastSeen(connectedID);
     }
+  };
+
+  // Runs when a secure connection with a user is established
+  const onEstablishedSecureConnection = (connectedID: string) => {
+    console.log('(onEstablishedSecureConnection) Secure connection established with:', connectedID);
+  };
+
+  // Runs when a secure connection cannot be made
+  const onFailedToEstablishSecureConnection = (connectedID: string, error: string) => {
+    console.log(
+      '(onFailedToEstablishSecureConnection) Failed to establish secure connection with:',
+      connectedID,
+      'with error:',
+      error
+    );
   };
 
   // Runs on message successfully dispatched, does not mean it was received by the recipient.

--- a/src/pages/Chat/ChatPage.tsx
+++ b/src/pages/Chat/ChatPage.tsx
@@ -62,11 +62,11 @@ const ChatPage = ({ route, navigation }: Props) => {
   */
 
   // Cause page refresh when allContacts changes.
-  useEffect(() => {
-    if (contactID) {
-      setLocalContactInfo(getContactInfo(contactID));
-    }
-  }, [allContacts]); // eslint-disable-line react-hooks/exhaustive-deps
+  // useEffect(() => {
+  //   if (contactID) {
+  //     setLocalContactInfo(getContactInfo(contactID));
+  //   }
+  // }, [allContacts]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Runs on mount. Sets up the chat page.
   useEffect(() => {
@@ -226,11 +226,17 @@ const ChatPage = ({ route, navigation }: Props) => {
 
       // Show failed messages with a retry on click.
       if (message.statusFlag === MessageStatus.FAILED) {
-        return <TextBubble message={message} callback={() => sendMessageAgain(message)} />;
+        return (
+          <TextBubble
+            key={message.messageID}
+            message={message}
+            callback={() => sendMessageAgain(message)}
+          />
+        );
       }
 
       // Normal messages.
-      return <TextBubble message={message} />;
+      return <TextBubble key={message.messageID} message={message} />;
     });
   };
 

--- a/src/services/bridgefy-link.ts
+++ b/src/services/bridgefy-link.ts
@@ -6,8 +6,12 @@ const eventEmitter = new NativeEventEmitter(BridgefySwift);
 enum supportedEvents {
   onDidStart = 'onDidStart',
   onFailedToStart = 'onFailedToStart',
+  onDidStop = 'onDidStop',
+  onDidFailToStop = 'onDidFailToStop',
   onDidConnect = 'onDidConnect',
   onDidDisconnect = 'onDidDisconnect',
+  onEstablishedSecureConnection = 'onEstablishedSecureConnection',
+  onFailedToEstablishSecureConnection = 'onFailedToEstablishSecureConnection',
   onMessageSent = 'onMessageSent',
   onMessageSentFailed = 'onMessageSentFailed',
   onDidRecieveMessage = 'onDidRecieveMessage',
@@ -32,10 +36,14 @@ function callbackHandler(resolve: (value: any) => void, reject: (reason?: any) =
 
 // do these listeners need to be destroyed at any point?
 export const createListeners = (
-  onStart: (userID: string) => void,
+  onStart: () => void,
   onFailedToStart: (error: string) => void,
+  onStop: () => void,
+  onFailedToStop: (error: string) => void,
   onConnect: (userID: string) => void,
   onDisconnect: (userID: string) => void,
+  onEstablishedSecureConnection: (userID: string) => void,
+  onFailedToEstablishSecureConnection: (userID: string, error: string) => void,
   onMessageReceived: (contactID: string, messageID: string, raw: string) => void,
   onMessageSent: (messageID: string) => void,
   onMessageSentFailed: (messageID: string, error: string) => void
@@ -47,7 +55,7 @@ export const createListeners = (
     supportedEvents.onDidStart,
     (data) => {
       console.log('(startListener): ', data);
-      onStart(data[0]);
+      onStart();
     }
   );
 
@@ -57,6 +65,24 @@ export const createListeners = (
     (data) => {
       console.log('(failedStartListener): ', data);
       onFailedToStart(data[0]);
+    }
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const stopListener: EmitterSubscription = eventEmitter.addListener(
+    supportedEvents.onDidStop,
+    (data) => {
+      console.log('(stopListener): ', data);
+      onStop();
+    }
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const failedToStopListener: EmitterSubscription = eventEmitter.addListener(
+    supportedEvents.onDidFailToStop,
+    (data) => {
+      console.log('(failedToStopListener): ', data);
+      onFailedToStop(data[0]);
     }
   );
 
@@ -77,6 +103,24 @@ export const createListeners = (
       console.log('(didDisconnectListener): ', data);
 
       onDisconnect(data[0]);
+    }
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const establishedSecureConnectionListener: EmitterSubscription = eventEmitter.addListener(
+    supportedEvents.onEstablishedSecureConnection,
+    (data) => {
+      console.log('(establishedSecureConnectionListener): ', data);
+      onEstablishedSecureConnection(data[0]);
+    }
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const failedToEstablishSecureConnectionListener: EmitterSubscription = eventEmitter.addListener(
+    supportedEvents.onFailedToEstablishSecureConnection,
+    (data) => {
+      console.log('(failedToEstablishSecureConnectionListener): ', data);
+      onFailedToEstablishSecureConnection(data[0], data[1]);
     }
   );
 
@@ -108,7 +152,7 @@ export const createListeners = (
   );
 };
 
-export async function startSDK() {
+export async function startSDK(): Promise<string> {
   console.log('(startSDK) Starting Bridgefy...');
   return new Promise((resolve, reject) => {
     BridgefySwift.startSDK(callbackHandler(resolve, reject));
@@ -119,5 +163,12 @@ export async function sendMessage(message: string, userID: string): Promise<stri
   console.log('(sendMessage) Sending message to: ', userID, message);
   return new Promise((resolve, reject) => {
     BridgefySwift.sendMessage(message, userID, callbackHandler(resolve, reject));
+  });
+}
+
+export async function getUserId(): Promise<string> {
+  console.log('(getUserId) Fetching user ID from Bridgefy...');
+  return new Promise((resolve, reject) => {
+    BridgefySwift.getUserId(callbackHandler(resolve, reject));
   });
 }


### PR DESCRIPTION
## Why
Bridgefy SDK 0.3.0 fixes an issue where the SDK couldn't start and adds Signal encryption.

Many of the class methods in the SDK changed so we need to fix how we interact with them.

## What Changed

- Update package
- Add new methods to Swift delegate
- Add listeners for delegate methods
- Get new error codes
- Change how we start the SDK to adapt to their new version
- Add key to message bubbles
- Fix error when opening chat for the first time with a new user

## Testing

- Make sure the app can launch now and works