### PR TITLE
use placeholder instead of value for onboarding

### DIFF
--- a/src/components/ui/TitleInput.tsx
+++ b/src/components/ui/TitleInput.tsx
@@ -4,21 +4,20 @@ import { StyleSheet, TextInput } from 'react-native';
 import { vars } from '../../utils/theme';
 
 interface Props {
-  text: string;
+  placeholder: string;
   onChangeText: (text: string) => void;
 }
 
 const TitleInput = React.forwardRef<TextInput & PropsWithChildren<InputProps>, Props>(
-  ({ text, onChangeText }, ref) => {
+  ({ onChangeText, placeholder }, ref) => {
     return (
       <Input
         ref={ref}
         inputContainerStyle={styles.inputContainer}
         containerStyle={styles.container}
         inputStyle={[styles.input]}
-        placeholder="Type here..."
+        placeholder={placeholder}
         placeholderTextColor={vars.gray.dark}
-        value={text}
         onChangeText={(value) => onChangeText(value)}
       />
     );

--- a/src/pages/Onboarding/ProfileOnboarding.tsx
+++ b/src/pages/Onboarding/ProfileOnboarding.tsx
@@ -48,7 +48,7 @@ export default function ProfileOnboarding() {
         <View style={styles.inputContainer}>
           <TitleInput
             ref={input}
-            text={nameText}
+            placeholder={nameText}
             onChangeText={(value: string) => {
               setNameText(value);
             }}


### PR DESCRIPTION
## Why
Most people who click the input want to change their name. It's high friction to backspace everything.

## What Changed
Instead of prepopulating the value of the onboarding nickname input with the pregenerated nickname, we instead put it as a placeholder. It is easier to override but will act the exact same.

## Testing
Try going through regular onboarding flow with and without setting a user name. It should be fast :)

## Extra
