### PR TITLE
Limit Firebase logs

### DIFF
--- a/ios/Hyperlocal.xcodeproj/xcshareddata/xcschemes/Hyperlocal 1.xcscheme
+++ b/ios/Hyperlocal.xcodeproj/xcshareddata/xcschemes/Hyperlocal 1.xcscheme
@@ -53,7 +53,7 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "-FIRDebugEnabled"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/ios/Hyperlocal/AppDelegate.mm
+++ b/ios/Hyperlocal/AppDelegate.mm
@@ -17,6 +17,7 @@
   bool didFinish=[super application:application didFinishLaunchingWithOptions:launchOptions];
     
   // Start Firebase
+  [[FIRConfiguration sharedInstance] setLoggerLevel:FIRLoggerLevelError];
   [FIRApp configure];
   [RNSplashScreen show];
   return didFinish;

--- a/src/hooks/useInitializeApp.ts
+++ b/src/hooks/useInitializeApp.ts
@@ -34,14 +34,13 @@ import {
   StoredPublicChatMessage,
 } from '../services/database';
 import { doesMessageExist, fetchConversation, fetchMessage } from '../services/message_storage';
-
-import Analytics from '@react-native-firebase/analytics';
 import {
   Message,
   sendChatInvitationResponseWrapper,
   sendConnectionInfoWrapper,
   sendNicknameUpdateWrapper,
 } from '../services/transmission';
+import { logEvent } from '../utils/analytics';
 import {
   isMessageChatInvitation,
   isMessageChatInvitationResponse,
@@ -317,7 +316,7 @@ export default function useInitializeApp() {
   // Runs on Bridgefy SDK start.
   async function onStart(_data: StartData) {
     console.log('(onStart) Started Bridgefy');
-    await Analytics().logEvent('onStart');
+    await logEvent('onStart');
     setBridgefyStatus(BridgefyStates.ONLINE);
   }
 
@@ -326,7 +325,7 @@ export default function useInitializeApp() {
     const error: string = data.error;
 
     console.log('(onFailedToStart) Failed to start:', error);
-    await Analytics().logEvent('onFailedToStart', { error });
+    await logEvent('onFailedToStart', { error });
 
     const errorCode: number = parseInt(error, 10);
     handleBridgefyError(errorCode);
@@ -335,7 +334,7 @@ export default function useInitializeApp() {
   // Runs on Bridgefy SDK stop.
   async function onStop(_data: StopData) {
     console.log('(onStop) Stopped');
-    await Analytics().logEvent('onStop');
+    await logEvent('onStop');
     setBridgefyStatus(BridgefyStates.OFFLINE);
   }
 
@@ -344,7 +343,7 @@ export default function useInitializeApp() {
     const error: string = data.error;
 
     console.log('(onFailedToStop) Failed to stop:', error);
-    await Analytics().logEvent('onFailedToStop', { error });
+    await logEvent('onFailedToStop', { error });
     setBridgefyStatus(BridgefyStates.FAILED);
   }
 
@@ -355,7 +354,7 @@ export default function useInitializeApp() {
     const connectedID: string = data.userID;
 
     console.log('(onConnect) Connected:', connectedID);
-    await Analytics().logEvent('onConnect', { connectedID });
+    await logEvent('onConnect', { connectedID });
 
     // Check if this is a valid connection.
     if (connectedID === NULL_UUID) {
@@ -387,7 +386,7 @@ export default function useInitializeApp() {
     const connectedID: string = data.userID;
 
     console.log('(onDisconnect) Disconnected:', connectedID);
-    await Analytics().logEvent('onDisconnect', { connectedID });
+    await logEvent('onDisconnect', { connectedID });
 
     // Check if this is a valid connection.
     if (connectedID === NULL_UUID) {
@@ -411,7 +410,7 @@ export default function useInitializeApp() {
   async function onEstablishedSecureConnection(data: EstablishedSecureConnectionData) {
     const connectedID: string = data.userID;
     console.log('(onEstablishedSecureConnection) Secure connection established with:', connectedID);
-    await Analytics().logEvent('onEstablishedSecureConnection', { connectedID });
+    await logEvent('onEstablishedSecureConnection', { connectedID });
   }
 
   // Runs when a secure connection cannot be made
@@ -425,7 +424,7 @@ export default function useInitializeApp() {
       'with error:',
       error
     );
-    await Analytics().logEvent('onFailedToEstablishSecureConnection', { connectedID, error });
+    await logEvent('onFailedToEstablishSecureConnection', { connectedID, error });
   }
 
   // Runs on message successfully dispatched, does not mean it was received by the recipient.
@@ -433,7 +432,7 @@ export default function useInitializeApp() {
     const messageID: string = data.messageID;
 
     console.log('(onMessageSent) Successfully dispatched message:', messageID);
-    await Analytics().logEvent('onMessageSent', { messageID });
+    await logEvent('onMessageSent', { messageID });
 
     // Check if this is a valid connection.
     if (messageID === NULL_UUID) {
@@ -479,7 +478,7 @@ export default function useInitializeApp() {
     const error: string = data.error;
 
     console.log('(onMessageSentFailed) Message failed to send, error:', error);
-    await Analytics().logEvent('onMessageSentFailed', { messageID, error });
+    await logEvent('onMessageSentFailed', { messageID, error });
 
     // Check if this is a valid connection.
     if (messageID === NULL_UUID) {
@@ -534,7 +533,7 @@ export default function useInitializeApp() {
     const transmission: string = data.transmission;
 
     console.log('(onMessageReceived) Received message:', contactID, messageID, raw, transmission);
-    await Analytics().logEvent('onMessageReceived', { contactID, messageID, transmission });
+    await logEvent('onMessageReceived', { contactID, messageID, transmission });
 
     // Sometimes we'll receive corrupted messages, so we don't want to crash the app.
     if (

--- a/src/services/bridgefy-link.ts
+++ b/src/services/bridgefy-link.ts
@@ -1,5 +1,5 @@
-import Analytics from '@react-native-firebase/analytics';
 import { EmitterSubscription, NativeEventEmitter, NativeModules } from 'react-native';
+import { logEvent } from '../utils/analytics';
 import {
   ConnectData,
   DisconnectData,
@@ -185,7 +185,7 @@ export const linkListenersToEvents = (handleEvent: (event: EventPacket) => void)
 
 export async function startSDK(): Promise<string> {
   console.log('(startSDK) Starting Bridgefy...');
-  await Analytics().logEvent('startSDK');
+  await logEvent('startSDK');
   return new Promise((resolve, reject) => {
     BridgefySwift.startSDK(callbackHandler(resolve, reject));
   });
@@ -193,7 +193,7 @@ export async function startSDK(): Promise<string> {
 
 export async function stopSDK(): Promise<string> {
   console.log('(stopSDK) Stopping Bridgefy...');
-  await Analytics().logEvent('stopSDK');
+  await logEvent('stopSDK');
   return new Promise((resolve, reject) => {
     BridgefySwift.stopSDK(callbackHandler(resolve, reject));
   });
@@ -205,7 +205,7 @@ export async function sendMessage(
   transmission: string = 'p2p'
 ): Promise<string> {
   console.log('(sendMessage) Sending message to: ', userID, message, transmission);
-  await Analytics().logEvent('sendMessage', { userID, transmission });
+  await logEvent('sendMessage', { userID, transmission });
   return new Promise((resolve, reject) => {
     BridgefySwift.sendMessage(message, userID, transmission, callbackHandler(resolve, reject));
   });
@@ -213,7 +213,7 @@ export async function sendMessage(
 
 export async function getUserId(): Promise<string> {
   console.log('(getUserId) Fetching user ID from Bridgefy...');
-  await Analytics().logEvent('getUserId');
+  await logEvent('getUserId');
   return new Promise((resolve, reject) => {
     BridgefySwift.getUserId(callbackHandler(resolve, reject));
   });
@@ -221,7 +221,7 @@ export async function getUserId(): Promise<string> {
 
 export async function getConnectedPeers(): Promise<string> {
   console.log('(getConnectedPeers) Fetching connected peers from Bridgefy...');
-  await Analytics().logEvent('getConnectedPeers');
+  await logEvent('getConnectedPeers');
   return new Promise((resolve, reject) => {
     BridgefySwift.getConnectedPeers(callbackHandler(resolve, reject));
   });

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,12 @@
+import Analytics from '@react-native-firebase/analytics';
+
+export async function logEvent(
+  event: string,
+  params?: {
+    [key: string]: any;
+  }
+) {
+  if (!__DEV__) {
+    await Analytics().logEvent(event, params);
+  }
+}


### PR DESCRIPTION
## Why
Firebase logs were bloating up the Xcode console.

We were getting these logs because we had Firebase's debug flag set for the Hyperlocal 1 scheme. This allowed the logs while we were testing to appear in Firebase's DebugView and be separated from the analytics in our production build. It is unfortunately [not possible](https://github.com/firebase/firebase-ios-sdk/issues/5704) to have that flag set and disable the logs. Instead, I disabled the debug flag but added an extra condition to the FIrebase log event function so that it will only log while on the production build.

## What Changed

- Disabled Firebase's debug flag
- Set log level to only show errors from Firebase
- Don't log events on dev build

## Testing

## Extra
