### PR TITLE
Only allow sending direct messages when connected

### DIFF
--- a/src/components/ui/ChatKeyboardView.tsx
+++ b/src/components/ui/ChatKeyboardView.tsx
@@ -72,7 +72,7 @@ const KeyboardView = ({ bubbles, buttonState, sendText }: Props) => {
             icon={buttonState && !isMessageDisabled ? <SendIcon /> : <SendIconDisabled />}
             buttonStyle={styles.sendButton}
             disabledStyle={styles.sendButtonDisabled}
-            disabled={isMessageDisabled && !buttonState}
+            disabled={isMessageDisabled || !buttonState}
             onPress={() => {
               if (buttonState) {
                 input.current.clear();

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -208,7 +208,14 @@ const ChatPage = ({ route, navigation }: NavigationProps) => {
 
       <KeyboardView
         bubbles={renderBubbles()}
-        buttonState={!!(contactID && allContacts.includes(contactID) && isAcceptedRequest)}
+        buttonState={
+          !!(
+            contactID &&
+            allContacts.includes(contactID) &&
+            isAcceptedRequest &&
+            connections.includes(contactID)
+          )
+        }
         sendText={sendText}
       />
     </SafeAreaView>


### PR DESCRIPTION
## Why
This used to be the case but we changed it because mesh was added. Now that mesh has been temporarily disabled we should no longer allow users to send messages to users they are not connected to.

## What Changed

- Added extra condition to send message button state
- Fixed error in logic of button disabled condition from ChatKeyboardView