### PR TITLE
HYP-165: Fix Android button click animation

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,15 +1,22 @@
-import { Button as RneuiButton } from '@rneui/base';
+import { Button as RneuiButton, ButtonProps } from '@rneui/base';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { vars } from '../../utils/theme';
 
 const BORDER_RADIUS = 32;
 
-const Button = (props: any) => {
+interface Props extends ButtonProps {
+  styles?: {
+    wrapper?: StyleProp<ViewStyle>;
+    button?: StyleProp<ViewStyle>;
+  };
+}
+
+const Button = (props: Props) => {
   return (
-    <View style={styles.buttonWrapper}>
+    <View style={[styles.buttonWrapper, props.styles?.wrapper]}>
       <RneuiButton
-        buttonStyle={[styles.buttonStyleDefault, props.style]}
+        buttonStyle={[styles.buttonStyleDefault, props.styles?.button]}
         titleStyle={styles.textStyleDefault}
         disabledTitleStyle={styles.textStyleDisabled}
         disabledStyle={styles.buttonStyleDisabled}
@@ -23,6 +30,7 @@ const styles = StyleSheet.create({
   buttonWrapper: {
     borderRadius: BORDER_RADIUS,
     overflow: 'hidden',
+    // height: '100%',
   },
   buttonStyleDefault: {
     backgroundColor: vars.primaryColor.button,

--- a/src/pages/Onboarding/GetStartedOnboarding.tsx
+++ b/src/pages/Onboarding/GetStartedOnboarding.tsx
@@ -33,7 +33,10 @@ const GetStartedOnboarding = () => {
           </Text>
           <Button
             title="Get Started"
-            style={styles.buttonStyle}
+            styles={{
+              wrapper: styles.buttonWrapperStyle,
+              button: styles.buttonStyle,
+            }}
             onPress={() => navigation.navigate('ProfileOnboarding')}
           />
         </View>
@@ -95,12 +98,13 @@ const styles = StyleSheet.create({
     marginTop: 10,
     marginRight: 20,
   },
-
-  buttonStyle: {
+  buttonWrapperStyle: {
     width: '100%',
     marginTop: 15,
   },
-
+  buttonStyle: {
+    width: '100%',
+  },
   popUpLinkText: {
     textDecorationLine: 'underline',
   },


### PR DESCRIPTION
## Why
Looks ugly

## What Changed

- Added wrapper around button to stop the ripple effect from going over the corners

## Extra

Before

https://user-images.githubusercontent.com/33498069/229258100-cf607e85-a82f-490b-bec1-c1832a61e0ed.mp4

After

https://user-images.githubusercontent.com/33498069/229258083-0a2f748f-491e-44b0-8253-57f35a0eb4cc.mp4

