### PR TITLE
Message versioning to ensure backwards compatibility.

### DIFF
--- a/src/services/transmission.ts
+++ b/src/services/transmission.ts
@@ -21,7 +21,8 @@ import { saveChatMessageToStorage } from './direct_messages';
  
 */
 export enum MESSAGE_TRANSMISSION_VERSION {
-  INITIAL = 1,
+  PRE_VERSIONING = 0,
+  INITIAL,
 }
 /*
   Message


### PR DESCRIPTION
We now include message versions to ensure backwards compatibility with non-updated devices with breaking message transmission changes.
Tested with old devices, non-breaking message transmission change.