### PR TITLE
HYP-162: Add signal encryption to all chats

### DIFF
--- a/src/components/features/Chat/ChatHeader.tsx
+++ b/src/components/features/Chat/ChatHeader.tsx
@@ -1,7 +1,7 @@
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Button, Text } from '@rneui/themed';
 import { useAtom } from 'jotai';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { RootStackParamList } from '../../../App';
 import {
@@ -26,10 +26,17 @@ const ChatHeader = ({ navigation, contactID }: Props) => {
   const [allContactsInfo] = useAtom(contactInfoAtom);
   const [allContacts] = useAtom(allContactsAtom);
   const [connectionInfo] = useAtom(connectionInfoAtomInterface);
+  const [connecting, setConnecting] = useState(true);
 
   const name = allContacts.includes(contactID)
     ? allContactsInfo[contactID].nickname
     : getConnectionName(contactID, connectionInfo);
+
+  useEffect(() => {
+    if (!allContacts.includes(contactID)) {
+      setTimeout(() => setConnecting(false), 3000);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <View style={styles.container}>
@@ -43,14 +50,14 @@ const ChatHeader = ({ navigation, contactID }: Props) => {
           {name}
         </Text>
         <View style={styles.bubble}>
-          {allContacts.includes(contactID) && allContactsInfo[contactID].isSecure ? (
+          {allContacts.includes(contactID) ? (
             <LastSeenBubble user={contactID} />
-          ) : allContacts.includes(contactID) ? (
+          ) : connecting ? (
+            <AlertBubble primary={false} text="Connecting..." />
+          ) : (
             <TouchableOpacity onPress={() => establishSecureConnection(contactID)}>
               <AlertBubble primary={false} text="Connection failed. Retry?" />
             </TouchableOpacity>
-          ) : (
-            <AlertBubble primary={false} text="Requested chat" />
           )}
         </View>
       </View>

--- a/src/components/features/Discover/NearbyAvatarGrid.tsx
+++ b/src/components/features/Discover/NearbyAvatarGrid.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../../services/atoms';
 import { establishSecureConnection } from '../../../services/bridgefy-link';
 import { getConnectionName } from '../../../services/connections';
-import { sendChatInvitationWrapper } from '../../../services/transmission';
 import NearbyAvatar from './NearbyAvatar';
 const NearbyAvatarGrid = ({ connections }: { connections: Array<string> }) => {
   const [connectionInfo] = useAtom(connectionInfoAtomInterface);
@@ -33,9 +32,6 @@ const NearbyAvatarGrid = ({ connections }: { connections: Array<string> }) => {
       if (!user.userID) {
         throw new Error('User not found and conversation clicked');
       }
-
-      // Send chat invitation message via Bridgefy.
-      sendChatInvitationWrapper(connectionID, user.nickname);
 
       establishSecureConnection(connectionID);
 

--- a/src/hooks/useInitializeApp.ts
+++ b/src/hooks/useInitializeApp.ts
@@ -47,6 +47,7 @@ import { doesMessageExist, fetchConversation, fetchMessage } from '../services/m
 import {
   Message,
   sendChatInvitationResponseWrapper,
+  sendChatInvitationWrapper,
   sendConnectionInfoWrapper,
   sendNicknameUpdateWrapper,
 } from '../services/transmission';
@@ -472,10 +473,8 @@ export default function useInitializeApp() {
       connectedID,
     });
 
-    setAllContactsInfo((prev) => {
-      prev[connectedID] = { ...prev[connectedID], isSecure: true };
-      return { ...prev };
-    });
+    // Send chat invitation message via Bridgefy.
+    sendChatInvitationWrapper(connectedID, currentUserInfo.nickname);
   }
 
   // Runs when a secure connection cannot be made

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -188,12 +188,7 @@ const ChatPage = ({ route, navigation }: NavigationProps) => {
         <KeyboardView
           bubbles={renderBubbles()}
           buttonState={
-            !!(
-              contactID &&
-              allContacts.includes(contactID) &&
-              connections.includes(contactID) &&
-              allContactsInfo[contactID].isSecure
-            )
+            !!(contactID && allContacts.includes(contactID) && connections.includes(contactID))
           }
           sendText={sendText}
         />

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -39,7 +39,6 @@ export interface ContactInfo {
   unreadCount: number;
   firstMsgPointer?: string;
   lastMsgPointer?: string;
-  isSecure?: boolean;
 }
 
 /*


### PR DESCRIPTION
# Waiting for designs but PR ready otherwise

## Why
Security is heavily reduced if messages are not being sent securely

## What Changed

- Add `isSecure` boolean to contact info
- When a chat request is sent, also try connecting securely
- Don't allow sending messages if the connection is not secure
- Remove a bunch of props from ChatHeader and control logic in the component itself instead
- Add some UI to allow users to retry connecting securely if it initially fails