### PR TITLE
HYP-198: Fix failed to start error when exiting and re-entering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,7 +127,7 @@ export default function App(): JSX.Element {
       return;
     }
 
-    if (appStateVisible === 'active') {
+    if (appStateVisible === 'active' && bridgefyStatus !== BridgefyStates.ONLINE) {
       navigationRef.current.navigate('Loading');
       startSDK().catch((e) => console.error(e));
     }


### PR DESCRIPTION
## Why
Bug. 

We were stopping whenever the app went to inactive or background state but when you exit the app we hit both of those states so it tries to stop twice.

StartSDK was also being triggered when the app started and initially went active which was causing a double start.

## What Changed

- Don't stop SDK if it's already stopped
- Don't start SDK if it's already online
