### PR TITLE
Change org name from InternetActivism to Internet Activism

### DIFF
--- a/src/pages/LoadingPage.tsx
+++ b/src/pages/LoadingPage.tsx
@@ -182,7 +182,7 @@ const LoadingPage = () => {
           <View style={styles.bottomDialog}>
             <Text style={styles.bottomDialogText}>
               {
-                'A project by InternetActivism, a 501(c)(3) organization, in partnership with Bridgefy. '
+                'A project by Internet Activism, a 501(c)(3) organization, in partnership with Bridgefy. '
               }
               {/* <Text
                 style={[styles.bottomDialogText, styles.popUpLinkText]}


### PR DESCRIPTION
## Why
Branding update

## What Changed

- Update one usage of name from InternetActivism to Internet Activism

