### PR TITLE
Destroy Bridgefy session before onboarding

### DIFF
--- a/ios/RCTBridgefyModule.swift
+++ b/ios/RCTBridgefyModule.swift
@@ -32,7 +32,7 @@ import BridgefySDK
     do {
       if self.bridgefyInstance == nil {
         try self.bridgefyInstance = Bridgefy(withApiKey: apiKey, delegate: testDelegate, verboseLogging: true)
-        print("(swift-init) Initialized SDK")
+        print("(swift-startSDK) Initialized SDK")
       }
       
       guard let bridgefy = self.bridgefyInstance else {
@@ -44,11 +44,11 @@ import BridgefySDK
       callback([false, "Success"])
     } catch let error as BridgefyError {
       let errorCode: Int = getErrorCode(error: error)
-      print("(swift-init) Failed to initialize Bridgefy instance with error code \(errorCode)")
+      print("(swift-startSDK) Failed to initialize Bridgefy instance with error code \(errorCode)")
       callback([true, String(errorCode)])
     } catch {
       // Unknown error occurred
-      print("(swift-init) Failed to initialize Bridgefy instance with unknown error code")
+      print("(swift-startSDK) Failed to initialize Bridgefy instance with unknown error code")
       callback([true, String(-1)])
     }
   }
@@ -170,13 +170,26 @@ import BridgefySDK
   @objc func destroySession(
     _ callback: RCTResponseSenderBlock
   ) {
-    guard let bridgefy = self.bridgefyInstance else {
-      callback([true, "28"])
-      return
+    do {
+      if self.bridgefyInstance == nil {
+        try self.bridgefyInstance = Bridgefy(withApiKey: apiKey, delegate: testDelegate, verboseLogging: true)
+        print("(swift-destroySession) Initialized SDK")
+      }
+      
+      guard let bridgefy = self.bridgefyInstance else {
+        callback([true, "28"])
+        return
+      }
+      
+      bridgefy.destroySession()
+      callback([false, "Success"])
+    } catch let error as BridgefyError {
+      let errorCode: Int = getErrorCode(error: error)
+      callback([true, String(errorCode)])
+    } catch {
+      // Unknown error occurred
+      callback([true, String(-1)])
     }
-    
-    bridgefy.destroySession()
-    callback([false, "Success"])
   }
 }
 

--- a/src/pages/LoadingPage.tsx
+++ b/src/pages/LoadingPage.tsx
@@ -11,7 +11,7 @@ import { RootStackParamList } from '../App';
 import PopUp from '../components/common/PopUp';
 import LogoIcon from '../components/ui/Icons/LogoIcon';
 import { bridgefyStatusAtom, currentUserInfoAtom } from '../services/atoms';
-import { startSDK, stopSDK } from '../services/bridgefy-link';
+import { destroySession, startSDK, stopSDK } from '../services/bridgefy-link';
 import {
   BridgefyErrors,
   BridgefyState,
@@ -106,6 +106,7 @@ const LoadingPage = () => {
           }),
         200
       );
+      destroySession();
       return;
     }
 


### PR DESCRIPTION
## Why
An attempt to fix the unknown user error where IDs from older installations appear

## What Changed

- Call destroy session when navigating to onboarding
- Handle Bridgefy not initialized case in destroy session swift function
