### PR TITLE
Ignore messages that are not text messages when showing delivered label

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -180,7 +180,14 @@ const ChatPage = ({ route, navigation }: NavigationProps) => {
         continue;
       }
 
-      const nextMessage = messages[i + 1] ?? undefined;
+      let nextMessage: StoredDirectChatMessage | undefined;
+      for (let j = i + 1; j < messages.length; j++) {
+        if (messages[j].typeFlag === MessageType.TEXT) {
+          nextMessage = messages[j];
+          break;
+        }
+      }
+
       const showDelivered =
         message.statusFlag === MessageStatus.DELIVERED &&
         message.isReceiver === false &&


### PR DESCRIPTION
## Why
Delivered tags were being put on the wrong messages

## What Changed

- Make sure that the next message we are checking is a text message

